### PR TITLE
changed regex of problems to match exactly the output expected

### DIFF
--- a/problems/for-loop/index.js
+++ b/problems/for-loop/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/45/.test(result)) cb(true);
+    if (/^45\n$/.test(result)) cb(true);
     else cb(false);
   });
 };

--- a/problems/function-arguments/index.js
+++ b/problems/function-arguments/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/4140/.test(result)) cb(true);
+    if (/^4140\n$/.test(result)) cb(true);
     else cb(false);
   });
 };

--- a/problems/functions/index.js
+++ b/problems/functions/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/bananas tasted really good./.test(result)) cb(true);
+    if (/^bananas tasted really good.\n$/.test(result)) cb(true);
     else cb(false);
   });
 };

--- a/problems/if-statement/index.js
+++ b/problems/if-statement/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/The fruit name has more than five characters./.test(result)) cb(true);
+    if (/^The fruit name has more than five characters.\n$/.test(result)) cb(true);
     else cb(false);
   });
 };

--- a/problems/introduction/index.js
+++ b/problems/introduction/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/hello/.test(result)) cb(true);
+    if (/^hello\n$/.test(result)) cb(true);
     else cb(false);
   });
 };

--- a/problems/number-to-string/index.js
+++ b/problems/number-to-string/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/128/.test(result)) cb(true);
+    if (/^128\n$/.test(result)) cb(true);
     else cb(false);
   });
 };

--- a/problems/numbers/index.js
+++ b/problems/numbers/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/123456789/.test(result)) cb(true);
+    if (/^123456789\n$/.test(result)) cb(true);
     else cb(false);
   });
 };

--- a/problems/revising-strings/index.js
+++ b/problems/revising-strings/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/pizza is wonderful/.test(result)) cb(true);
+    if (/^pizza is wonderful\n$/.test(result)) cb(true);
     else cb(false);
   });
 };

--- a/problems/strings/index.js
+++ b/problems/strings/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/this is a string/.test(result)) cb(true);
+    if (/^this is a string\n$/.test(result)) cb(true);
     else cb(false);
   });
 };

--- a/problems/variables/index.js
+++ b/problems/variables/index.js
@@ -10,7 +10,7 @@ exports.fail = getFile(path.join(__dirname, 'troubleshooting.md'));
 
 exports.verify = function (args, cb) {
   run(args[0], function (err, result) {
-    if (/some string/.test(result)) cb(true);
+    if (/^some string\n$/.test(result)) cb(true);
     else cb(false);
   });
 };


### PR DESCRIPTION
How it's done at the moment, if you write your introduction.js challenge with the following:

``` js
console.log('hellohello');
```

it will say that's correct if you run `javascripting verify introduction.js`. I think it's less confusing to check the exact output.
