### PR TITLE
Change workshopper-adventure dependency version to >=5.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "colors": "^1.0.3",
     "promise": "^7.1.1",
     "diff": "^1.2.1",
-    "workshopper-adventure": "^4.4.6"
+    "workshopper-adventure": "^5.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Problem described in issue #177 

I edited the dependencies in `package.json` to require workshopper-adventure to be at least version 5.0.0. When installing this, there was no more warning.