### PR TITLE
add a contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,19 @@
 # Contributing
 
-Contributions are welcome! For instructions and help creating a great pull request, please read the [workshopper contributing document](https://github.com/workshopper/org/blob/master/CONTRIBUTING.md).
+Code contributions are welcome and high encouraged! For instructions and help creating a great pull request, please read the [workshopper contributing document](https://github.com/workshopper/org/blob/master/CONTRIBUTING.md).
 
 If you have questions about contributing, please create an issue.
 
-## Current Stewards
+## Lead Maintainers
 
-- you?
+The role of lead maintainers is to triage and categorize issues, answer questions about contributing to the repository, review and give feedback on PRs, and maintain the quality of a workshopper's codebase and repository.
+
+### Current Team
+
+[link to github]()
+
+### Volunteer
+
+Submitting many PRs? Please volunteer to lead this repository! Lead maintainers are selected in the philosophy of [Open Open Source](http://openopensource.org/):
+
+> Individuals making significant and valuable contributions are given commit-access to the project to contribute as they see fit. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Contributions are welcome! For instructions and help creating a great pull request, please read the [workshopper contributing document](https://github.com/workshopper/org/blob/master/CONTRIBUTING.md).
+
+If you have questions about contributing, please create an issue.
+
+## Current Stewards
+
+- you?


### PR DESCRIPTION
Added a contributing doc which is mostly a link to the document in `workshopper/org`. I did make a section for outlining who the workshopper "stewards" are. My idea is that a few people could be designated as the "first responders" for triaging issues, responding to questions, and merging PRs. While anyone can and should feel free to pitch in and help maintain the repo, these folks would step up as leaders and taking charge of the workshopper while they are in that role. Original authors and current maintainers would have first preference for that role. Thoughts?