### PR TITLE
Added Lead Maintainers list.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,12 @@ If you have questions about contributing, please create an issue.
 
 The role of lead maintainers is to triage and categorize issues, answer questions about contributing to the repository, review and give feedback on PRs, and maintain the quality of a workshopper's codebase and repository.
 
-[Current Lead Maintainers](https://github.com/orgs/workshopper/teams/javascripting-leads)
+**Current Lead Maintainers**
+- Seth Vincent [@sethvincent](https://github.com/sethvincent)
+- Adam Brady [@SomeoneWeird](https://github.com/SomeoneWeird)
+- Anshul [@AnshulMalik](https://github.com/AnshulMalik)
+- Martin Splitt [@AVGP](https://github.com/AVGP)
+- Seth [@itzsaga](https://github.com/itzsaga)
 
 ### Volunteer
 


### PR DESCRIPTION
Put the Lead Maintainers list inline for now. If the group grows too large it should be made into it's own file.