### PR TITLE
Update Node.js download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Having issues with javascripting? Get help troubleshooting in the [nodeschool di
 
 Make sure Node.js is installed on your computer.
 
-Install it from [nodejs.org/download](http://nodejs.org/download)
+Install it from [nodejs.org](https://nodejs.org/)
 
 On Windows and using v4 or v5 of Node.js? Make sure you are using at least 5.1.0, which provides a fix for a bug on Windows where you can't choose items in the menu.
 


### PR DESCRIPTION
Changes the link to point to the https://nodejs.org/ homepage instead of the download folder. The homepage has a big download link that autodetects people's OS, which is important for beginners looking at this README.

The previous page is a folder listing at the moment, which just doesn't work well for first timers trying to get up and running.