### PR TITLE
Fixed missing gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Get help
 Having issues with javascripting? Get help troubleshooting in the [nodeschool discussions repo](http://github.com/nodeschool/discussions), or on gitter:
 
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/nodeschool/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/nodeschool/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Install Node.js
 


### PR DESCRIPTION
Noticed the gitter badge was missing and found an SVG hosted by shields.io