### PR TITLE
[Fix #145] Update dependency that caused the error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "colors": "^1.0.3",
     "promise": "^7.1.1",
     "diff": "^1.2.1",
-    "workshopper-adventure": "^5.0.0"
+    "workshopper-adventure": "^6.0.3"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
The issue described in #145 is due to the `workshopper-adventure` dependency, which have been now fixed (see merged pull request: https://github.com/workshopper/workshopper-adventure/pull/95)

Updating here this dependency to `workshopper-adventure` will fix the problem.

Hope that helps.