### PR TITLE
Added note on how to fix EACCESS error for PS and CMD users

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ The `--global` option installs this module globally so that you can run it as a 
 
 #### Having issues with installation?
 
-If you get an `EACCESS` error, the simplest way to fix this is to rerun the command, prefixed with sudo:
+If you get an `EACCESS` error, the simplest way to fix this is to rerun the command, in either of the following ways:
 
-```
-sudo npm install --global javascripting
-```
+- On unix shells, prefix the command with sudo
+> `sudo npm install --global javascripting`
+
+- On Windows and if using either PowerShell or CMD, ensure you open the shell with administrator privilege.
 
 You can also fix the permissions so that you don't have to use `sudo`. Take a look at this npm documentation:
 https://docs.npmjs.com/getting-started/fixing-npm-permissions


### PR DESCRIPTION
The doc most likely targets a lot of noob programmers like me :-D

Since `sudo` is usually irrelevant on Windows and some noobs could be running `node` and `npm` with **_PowerShell_** or **_CMD_** on Windows, it makes sense to explicitly explain that the equivalent of `sudo` on Windows is to start the shell with admin privilege.