### PR TITLE
Fix typo

### DIFF
--- a/problems/scope/problem.md
+++ b/problems/scope/problem.md
@@ -29,7 +29,7 @@ IIFE, Immediately Invoked Function Expression, is a common pattern for creating 
 
 Example:
 ```js
-(function () { // the function expression is surrounded by parenthesis
+(function () { // the function expression is surrounded by parentheses
   // variables defined here
   // can't be accessed outside
 })() // the function is immediately invoked


### PR DESCRIPTION
The correct word to use is "parentheses" since there is more than one parenthesis surrounding the function expression. "Parentheses" is the plural form of "parenthesis."